### PR TITLE
Fixed linking to boost::thread for trac_ik.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Boost configuration
-find_package(Boost COMPONENTS system filesystem program_options REQUIRED)
+find_package(Boost COMPONENTS system thread filesystem program_options REQUIRED)
 add_definitions(-DBOOST_BIND_GLOBAL_PLACEHOLDERS)
 
 # External dependencies
@@ -42,6 +42,7 @@ get_directory_property(WRAPPERS_LINK_DIR DIRECTORY src/planners DEFINITION WRAPP
 set(MOTIONPLANNER_LIB_INCLUDES
     ${CMAKE_SOURCE_DIR}/include
     ${EIGEN3_INCLUDE_DIR}
+    ${BOOST_INCLUDE_DIR}
     ${BASE_TYPES_INCLUDE_DIRS}
     ${BASE_LOGGING_INCLUDE_DIRS}
     ${OROCOS_KDL_INCLUDE_DIRS}
@@ -60,6 +61,7 @@ set(MOTIONPLANNER_LIB_INCLUDES
 
 set(MOTIONPLANNER_DEP_LIBS
     Boost::system
+    Boost::thread
     Boost::filesystem
     Boost::program_options
     ${BASE_TYPES_LIBRARY}

--- a/test/config/trac_ik_config.yml
+++ b/test/config/trac_ik_config.yml
@@ -1,0 +1,24 @@
+trac_ik_config:
+  # can be :SPEED, :DISTANCE, :MANIP1 or :MANIP2
+  solver_type: :SPEED
+
+  # time out - used if trac ik is available
+  timeout_sec: 0.1
+
+  # stopping criteria for the numerical solver. Stop the solver, if the error is below the eps.              
+  eps: 0.001
+
+  # End Effector Pose Tolerance - used for setting the tolerances in trac_ik
+  tolerances:
+    - 6.0
+    - 0.0
+
+  # weight each of the seven joints with 1/7
+  joints_err_weight:
+    - 0.1428
+    - 0.1428
+    - 0.1428
+    - 0.1428
+    - 0.1428
+    - 0.1428
+    - 0.1428


### PR DESCRIPTION
Adds trac_ik to the list of available motion planners.