### PR TITLE
Fixed placeholders in bound functions.

### DIFF
--- a/src/planners/include/wrapper/ompl/OmplPlanner.hpp
+++ b/src/planners/include/wrapper/ompl/OmplPlanner.hpp
@@ -7,6 +7,8 @@
 
 #include <urdf_model/model.h>
 
+// Fixes deprecated usage of global boost placeholders.
+#include <boost/bind/bind.hpp>
 
 #include <ompl/base/Planner.h>
 #include <ompl/base/SpaceInformation.h>

--- a/src/planners/src/wrappers/ompl/OmplPlanner.cpp
+++ b/src/planners/src/wrappers/ompl/OmplPlanner.cpp
@@ -101,6 +101,9 @@ bool OmplPlanner::setUpPlanningTaskInJointSpace(PlannerStatus &planner_status)
 
 bool OmplPlanner::solveTaskInJointSpace(base::JointsTrajectory &solution, PlannerStatus &planner_status)
 {
+    // Fixes deprecated usage of global boost placeholders, i.e., '_1'.
+    using namespace boost::placeholders;
+
     if(!setUpPlanningTaskInJointSpace(planner_status))
     {
         return false;
@@ -390,6 +393,9 @@ bool OmplPlanner::cartesianSpaceStateValidityChecker(const ompl::base::State *st
 
 bool OmplPlanner::solveTaskInCartesianSpace(base::JointsTrajectory &solution, PlannerStatus &planner_status)
 {
+    // Fixes deprecated usage of global boost placeholders, i.e., '_1'.
+    using namespace boost::placeholders;
+
     if(!setUpPlanningTaskInCartesianSpace(planner_status))
     {
         return false;


### PR DESCRIPTION
Global placeholders for boost::bind are deprecated and are to be explicitly loaded into the namespace for each function. 