### PR TITLE
Ignore collision between first link and environment

### DIFF
--- a/src/MotionPlannerUtils.cpp
+++ b/src/MotionPlannerUtils.cpp
@@ -689,6 +689,8 @@ std::string MotionPlanners::generateSRDF(const std::string &robotName, const std
     {
         if (!chainLinks.count(rl))
             continue;
+        if( rl == robotLinks[0])  // WORKAROUND: Ignore collisions of first Link with environment
+            continue;
 
         for (const auto &el : envLinks)
         {


### PR DESCRIPTION
Workaround. Ignore all collisions of the first (generally static) link with the environment links.